### PR TITLE
Add n8n workflow prototypes (WF2 + WF4)

### DIFF
--- a/workflow-n8n/README.md
+++ b/workflow-n8n/README.md
@@ -1,0 +1,65 @@
+# NovaSeat — n8n Workflows
+
+This folder contains the n8n workflow JSON files for the NovaSeat Churn Prevention Platform. Each file can be imported directly into n8n via **Settings → Import Workflow**.
+
+---
+
+## Workflow 2 — Churn Alert Monitor
+
+**File:** `workflow2-churn-alert-monitor.json`
+
+**Trigger:** Cron daily at 08:00 + manual trigger
+
+**Flow:**
+
+1. Query `v_churn_alerts` for accounts newly flagged as High/Critical
+2. Code node applies the decision logic based on `risk_tier` + ARR:
+   - **Critical + ARR > €50K** → `csm_escalation` — creates a Case, notifies the CSM via email, sends personalized outreach to the customer
+   - **Critical + ARR ≤ €50K** → `auto_outreach` — sends autonomous email with success call offer
+   - **High** → `product_tip` — sends personalized email with a feature recommendation based on the top SHAP churn driver
+3. For each account:
+   - INSERT into `interventions`
+   - INSERT into `outreach_messages`
+   - INSERT into `tasks` (assigned to the account's CSM)
+   - UPDATE `accounts.intervention_status` → `Active`
+   - (CSM escalation only) INSERT into `cases` + email notification to CSM
+
+**Email templates** are built dynamically in the Code node, with personalized content based on the account name, top churn driver, and strategy. Product tips are mapped from SHAP driver names to human-readable feature suggestions.
+
+---
+
+## Workflow 4 — Weekly Reporting
+
+**File:** `workflow4-weekly-reporting.json`
+
+**Trigger:** Cron every Monday at 08:00 + manual trigger
+
+**Flow:**
+
+1. Fetch last week's stats from `v_weekly_stats`
+2. Fetch current risk tier distribution from `accounts`
+3. Merge and build an HTML digest with:
+   - KPI cards: accounts intercepted, conversations started, churn prevented, CSM escalations
+   - Messaging stats: messages sent, replies received, reply rate
+   - Risk distribution table: Critical / High / Medium / Low breakdown
+4. UPSERT into `weekly_reports` (safe to re-run for the same week)
+5. Send the digest email to the Head of Customer Success
+
+---
+
+## Setup after import
+
+Both workflows require credentials to be configured in n8n:
+
+| Credential | Where | Notes |
+|---|---|---|
+| **NovaSeat PostgreSQL** | All Postgres nodes | `postgresql://novaseat:novaseat_secret@localhost:5432/novaseat` |
+| **NovaSeat SMTP** | All Email Send nodes | Configure with your mail provider (Gmail, SendGrid, Resend, etc.) |
+
+### Placeholders to replace
+
+| Placeholder | File | Description |
+|---|---|---|
+| `{{CSM_NAME}}` | WF2 | Replaced dynamically if CSM data is in DB; fallback needs manual config |
+| `{{CALENDAR_LINK}}` | WF2 | URL to the CSM's booking page (Cal.com, Calendly, Google Calendar) |
+| `{{HEAD_OF_CS_EMAIL}}` | WF4 | Email address of the Head of Customer Success |

--- a/workflow-n8n/workflow2-churn-alert-monitor.json
+++ b/workflow-n8n/workflow2-churn-alert-monitor.json
@@ -1,0 +1,295 @@
+{
+  "name": "WF2 — Churn Alert Monitor",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            { "field": "cronExpression", "expression": "0 8 * * *" }
+          ]
+        }
+      },
+      "id": "schedule-trigger",
+      "name": "Daily 08:00",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [0, 200]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT * FROM v_churn_alerts ORDER BY churn_probability DESC;",
+        "options": {}
+      },
+      "id": "fetch-alerts",
+      "name": "Fetch Churn Alerts",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [260, 100],
+      "credentials": {
+        "postgres": { "id": "CONFIGURE_ME", "name": "NovaSeat PostgreSQL" }
+      }
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.id }}",
+              "rightValue": "",
+              "operator": { "type": "string", "operation": "isNotEmpty" }
+            }
+          ],
+          "combinator": "and"
+        }
+      },
+      "id": "if-has-alerts",
+      "name": "Has Alerts?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [500, 100]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ── Determine strategy, build email, prepare DB payloads ──\n\nconst DRIVER_LABELS = {\n  days_since_last_login: 'low login activity',\n  events_per_month_trend: 'declining event creation',\n  support_ticket_velocity: 'frequent support tickets',\n  tenure_months: 'early tenure phase',\n  monthly_charges: 'plan cost concerns',\n  annual_revenue: 'revenue mismatch',\n  has_dedicated_csm: 'lack of dedicated CSM',\n  payment_auto: 'manual payment friction',\n  paperless_billing: 'billing preferences',\n  online_security: 'security feature gap',\n  online_backup: 'backup feature gap',\n  streaming_tv: 'unused streaming features',\n  senior_citizen: 'demographic factor',\n  has_partner: 'demographic factor',\n  has_dependents: 'demographic factor',\n  plan_type: 'plan type mismatch',\n  platform_tier: 'platform tier limitations',\n};\n\nfunction driverLabel(driver) {\n  return DRIVER_LABELS[driver] || driver.replace(/_/g, ' ');\n}\n\nfunction parseDrivers(raw) {\n  if (!raw) return [];\n  if (typeof raw === 'string') {\n    try { return JSON.parse(raw); } catch { return []; }\n  }\n  return Array.isArray(raw) ? raw : [];\n}\n\nfunction productTipFor(driver) {\n  const tips = {\n    days_since_last_login: { feature: 'Event Dashboard', tip: 'Your personalized Event Dashboard shows upcoming deadlines and attendee RSVPs at a glance — no need to dig through emails.' },\n    events_per_month_trend: { feature: 'AI Agenda Builder', tip: 'Our AI Agenda Builder can create a full event program in minutes. Customers who use it run 3x more events per quarter.' },\n    support_ticket_velocity: { feature: 'Help Center & Live Chat', tip: 'Our revamped Help Center has step-by-step guides for the most common workflows — many customers find answers faster than opening a ticket.' },\n  };\n  return tips[driver] || { feature: 'Live Polling', tip: 'Live Polling lets your attendees interact in real time — it is our most-loved feature with a 94% satisfaction rate.' };\n}\n\nconst items = $input.all();\nconst results = [];\n\nfor (const item of items) {\n  const a = item.json;\n  const risk = a.risk_tier;\n  const arr = parseFloat(a.annual_revenue) || 0;\n  const drivers = parseDrivers(a.churn_drivers);\n  const topDriverKey = drivers.length > 0 ? drivers[0].driver : 'days_since_last_login';\n  const topDriverLabel = driverLabel(topDriverKey);\n  const firstName = (a.name || '').split(' ')[0] || a.name;\n\n  let strategy, taskPriority, caseNeeded, emailSubject, emailBody;\n\n  // ── Decision logic from prompt.md ──\n  if (risk === 'Critical' && arr > 50000) {\n    strategy = 'csm_escalation';\n    taskPriority = 'Urgent';\n    caseNeeded = true;\n    emailSubject = `${firstName}, your dedicated success team is ready to help`;\n    emailBody = `<div style=\"font-family:Arial,sans-serif;max-width:600px;margin:0 auto;padding:24px;\">`\n      + `<h2 style=\"color:#1a1a2e;\">Hi ${firstName},</h2>`\n      + `<p>I'm <strong>{{CSM_NAME}}</strong>, your dedicated Customer Success Manager at NovaSeat.</p>`\n      + `<p>We noticed some signals that suggest you might not be getting full value from the platform — specifically <strong>${topDriverLabel}</strong>.</p>`\n      + `<p>Given how important NovaSeat is to your event operations, I'd love to schedule a quick call to understand what's going on and see how we can help.</p>`\n      + `<p><a href=\"{{CALENDAR_LINK}}\" style=\"display:inline-block;background:#4f46e5;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;font-weight:bold;\">Book a 15-min call with me</a></p>`\n      + `<p>Or simply reply to this email — I read every response personally.</p>`\n      + `<p style=\"margin-top:24px;\">Best,<br/><strong>{{CSM_NAME}}</strong><br/>Customer Success, NovaSeat</p>`\n      + `</div>`;\n\n  } else if (risk === 'Critical') {\n    strategy = 'auto_outreach';\n    taskPriority = 'High';\n    caseNeeded = false;\n    emailSubject = `${firstName}, let's get NovaSeat working better for you`;\n    emailBody = `<div style=\"font-family:Arial,sans-serif;max-width:600px;margin:0 auto;padding:24px;\">`\n      + `<h2 style=\"color:#1a1a2e;\">Hi ${firstName},</h2>`\n      + `<p>We've noticed some changes in how you're using NovaSeat — particularly <strong>${topDriverLabel}</strong> — and we want to make sure everything is running smoothly.</p>`\n      + `<p>Here are a few things that might help:</p>`\n      + `<ul>`\n      + `<li><strong>Book a free success call</strong> — we'll walk through your setup and optimize it: <a href=\"{{CALENDAR_LINK}}\">Pick a time</a></li>`\n      + `<li><strong>Reply to this email</strong> with any questions or concerns</li>`\n      + `<li><strong>Visit our Help Center</strong> for quick self-service guides</li>`\n      + `</ul>`\n      + `<p>We're here to help you get the most out of every event.</p>`\n      + `<p style=\"margin-top:24px;\">The NovaSeat Team</p>`\n      + `</div>`;\n\n  } else {\n    // High risk → product tip\n    strategy = 'product_tip';\n    taskPriority = 'Medium';\n    caseNeeded = false;\n    const tip = productTipFor(topDriverKey);\n    emailSubject = `${firstName}, have you tried ${tip.feature}?`;\n    emailBody = `<div style=\"font-family:Arial,sans-serif;max-width:600px;margin:0 auto;padding:24px;\">`\n      + `<h2 style=\"color:#1a1a2e;\">Hi ${firstName},</h2>`\n      + `<p>We wanted to share a feature that customers in a similar situation find really valuable:</p>`\n      + `<div style=\"background:#f8f7ff;border-left:4px solid #4f46e5;padding:16px;margin:16px 0;border-radius:4px;\">`\n      + `<strong>${tip.feature}</strong><br/>${tip.tip}`\n      + `</div>`\n      + `<p>If you'd like a quick walkthrough, just reply to this email or <a href=\"{{CALENDAR_LINK}}\">book a 10-minute demo</a>.</p>`\n      + `<p style=\"margin-top:24px;\">The NovaSeat Team</p>`\n      + `</div>`;\n  }\n\n  results.push({\n    json: {\n      // account data (pass through)\n      account_id: a.id,\n      account_name: a.name,\n      account_email: a.email,\n      annual_revenue: arr,\n      plan_type: a.plan_type,\n      risk_tier: risk,\n      churn_probability: a.churn_probability,\n      churn_drivers: a.churn_drivers,\n      csm_id: a.csm_id,\n      csm_name: a.csm_name,\n      csm_email: a.csm_email,\n      days_since_last_login: a.days_since_last_login,\n      // computed\n      strategy,\n      taskPriority,\n      caseNeeded,\n      emailSubject,\n      emailBody,\n      taskTitle: `Follow up: ${a.name} — ${risk} risk (${strategy})`,\n      taskDescription: `Account ${a.name} flagged as ${risk} risk (churn probability ${a.churn_probability}). Top driver: ${topDriverLabel}. Strategy: ${strategy}.`,\n    }\n  });\n}\n\nreturn results;"
+      },
+      "id": "determine-strategy",
+      "name": "Determine Strategy & Build Email",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [740, 0]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "INSERT INTO interventions (account_id, csm_id, trigger_risk_tier, trigger_arr, strategy, status)\nVALUES (\n  '{{ $json.account_id }}',\n  {{ $json.csm_id ? \"'\" + $json.csm_id + \"'\" : 'NULL' }},\n  '{{ $json.risk_tier }}',\n  {{ $json.annual_revenue }},\n  '{{ $json.strategy }}',\n  'Active'\n)\nRETURNING id;",
+        "options": {}
+      },
+      "id": "insert-intervention",
+      "name": "Insert Intervention",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [1000, 0],
+      "credentials": {
+        "postgres": { "id": "CONFIGURE_ME", "name": "NovaSeat PostgreSQL" }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Merge intervention ID with previous data\nconst prev = $('Determine Strategy & Build Email').item.json;\nconst interventionId = $json.id;\nreturn [{ json: { ...prev, intervention_id: interventionId } }];"
+      },
+      "id": "merge-intervention-id",
+      "name": "Merge Intervention ID",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1240, 0]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "INSERT INTO outreach_messages (intervention_id, account_id, channel, subject, body_html, recipient_email, status, sent_at)\nVALUES (\n  '{{ $json.intervention_id }}',\n  '{{ $json.account_id }}',\n  'Email',\n  '{{ $json.emailSubject }}',\n  '{{ $json.emailBody }}',\n  '{{ $json.account_email }}',\n  'Sent',\n  NOW()\n)\nRETURNING id;",
+        "options": {}
+      },
+      "id": "insert-outreach",
+      "name": "Insert Outreach Message",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [1480, 0],
+      "credentials": {
+        "postgres": { "id": "CONFIGURE_ME", "name": "NovaSeat PostgreSQL" }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "INSERT INTO tasks (intervention_id, account_id, assigned_to, title, description, priority, status, due_date)\nVALUES (\n  '{{ $('Merge Intervention ID').item.json.intervention_id }}',\n  '{{ $('Merge Intervention ID').item.json.account_id }}',\n  {{ $('Merge Intervention ID').item.json.csm_id ? \"'\" + $('Merge Intervention ID').item.json.csm_id + \"'\" : 'NULL' }},\n  '{{ $('Merge Intervention ID').item.json.taskTitle }}',\n  '{{ $('Merge Intervention ID').item.json.taskDescription }}',\n  '{{ $('Merge Intervention ID').item.json.taskPriority }}',\n  'Open',\n  NOW() + INTERVAL '3 days'\n);",
+        "options": {}
+      },
+      "id": "insert-task",
+      "name": "Insert Task",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [1720, 0],
+      "credentials": {
+        "postgres": { "id": "CONFIGURE_ME", "name": "NovaSeat PostgreSQL" }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "UPDATE accounts SET intervention_status = 'Active' WHERE id = '{{ $('Merge Intervention ID').item.json.account_id }}';",
+        "options": {}
+      },
+      "id": "update-account",
+      "name": "Update Account Status",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [1960, 0],
+      "credentials": {
+        "postgres": { "id": "CONFIGURE_ME", "name": "NovaSeat PostgreSQL" }
+      }
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true },
+          "conditions": [
+            {
+              "leftValue": "={{ $('Merge Intervention ID').item.json.caseNeeded }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "true" }
+            }
+          ],
+          "combinator": "and"
+        }
+      },
+      "id": "if-case-needed",
+      "name": "Case Needed?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [2200, 0]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "INSERT INTO cases (intervention_id, account_id, assigned_to, title, description, priority, status, escalated_at)\nVALUES (\n  '{{ $('Merge Intervention ID').item.json.intervention_id }}',\n  '{{ $('Merge Intervention ID').item.json.account_id }}',\n  {{ $('Merge Intervention ID').item.json.csm_id ? \"'\" + $('Merge Intervention ID').item.json.csm_id + \"'\" : 'NULL' }},\n  'Critical churn risk: {{ $('Merge Intervention ID').item.json.account_name }} (ARR €{{ $('Merge Intervention ID').item.json.annual_revenue }})',\n  '{{ $('Merge Intervention ID').item.json.taskDescription }}',\n  'Critical',\n  'Open',\n  NOW()\n);",
+        "options": {}
+      },
+      "id": "insert-case",
+      "name": "Insert Case (High ARR)",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [2440, -100],
+      "credentials": {
+        "postgres": { "id": "CONFIGURE_ME", "name": "NovaSeat PostgreSQL" }
+      }
+    },
+    {
+      "parameters": {
+        "fromEmail": "noreply@novaseat.dev",
+        "toEmail": "={{ $('Merge Intervention ID').item.json.account_email }}",
+        "subject": "={{ $('Merge Intervention ID').item.json.emailSubject }}",
+        "html": "={{ $('Merge Intervention ID').item.json.emailBody }}",
+        "options": {
+          "replyTo": "={{ $('Merge Intervention ID').item.json.csm_email || 'success@novaseat.dev' }}"
+        }
+      },
+      "id": "send-email",
+      "name": "Send Email",
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 2.1,
+      "position": [2700, 0],
+      "credentials": {
+        "smtp": { "id": "CONFIGURE_ME", "name": "NovaSeat SMTP" }
+      }
+    },
+    {
+      "parameters": {
+        "fromEmail": "noreply@novaseat.dev",
+        "toEmail": "={{ $('Merge Intervention ID').item.json.csm_email }}",
+        "subject": "=🚨 CSM Escalation: {{ $('Merge Intervention ID').item.json.account_name }} — Critical Risk (ARR €{{ $('Merge Intervention ID').item.json.annual_revenue }})",
+        "html": "=<div style=\"font-family:Arial,sans-serif;max-width:600px;padding:24px;\"><h2 style=\"color:#dc2626;\">Critical Account Escalation</h2><p><strong>Account:</strong> {{ $('Merge Intervention ID').item.json.account_name }}</p><p><strong>ARR:</strong> €{{ $('Merge Intervention ID').item.json.annual_revenue }}</p><p><strong>Churn Probability:</strong> {{ $('Merge Intervention ID').item.json.churn_probability }}</p><p><strong>Risk Tier:</strong> {{ $('Merge Intervention ID').item.json.risk_tier }}</p><p><strong>Top Churn Drivers:</strong> {{ JSON.stringify($('Merge Intervention ID').item.json.churn_drivers) }}</p><p>An outreach email has already been sent to the customer. Please follow up within 24 hours.</p></div>",
+        "options": {}
+      },
+      "id": "notify-csm",
+      "name": "Notify CSM (Escalation)",
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 2.1,
+      "position": [2700, -200],
+      "credentials": {
+        "smtp": { "id": "CONFIGURE_ME", "name": "NovaSeat SMTP" }
+      }
+    }
+  ],
+  "connections": {
+    "Daily 08:00": {
+      "main": [
+        [{ "node": "Fetch Churn Alerts", "type": "main", "index": 0 }]
+      ]
+    },
+    "Manual Trigger": {
+      "main": [
+        [{ "node": "Fetch Churn Alerts", "type": "main", "index": 0 }]
+      ]
+    },
+    "Fetch Churn Alerts": {
+      "main": [
+        [{ "node": "Has Alerts?", "type": "main", "index": 0 }]
+      ]
+    },
+    "Has Alerts?": {
+      "main": [
+        [{ "node": "Determine Strategy & Build Email", "type": "main", "index": 0 }],
+        []
+      ]
+    },
+    "Determine Strategy & Build Email": {
+      "main": [
+        [{ "node": "Insert Intervention", "type": "main", "index": 0 }]
+      ]
+    },
+    "Insert Intervention": {
+      "main": [
+        [{ "node": "Merge Intervention ID", "type": "main", "index": 0 }]
+      ]
+    },
+    "Merge Intervention ID": {
+      "main": [
+        [{ "node": "Insert Outreach Message", "type": "main", "index": 0 }]
+      ]
+    },
+    "Insert Outreach Message": {
+      "main": [
+        [{ "node": "Insert Task", "type": "main", "index": 0 }]
+      ]
+    },
+    "Insert Task": {
+      "main": [
+        [{ "node": "Update Account Status", "type": "main", "index": 0 }]
+      ]
+    },
+    "Update Account Status": {
+      "main": [
+        [{ "node": "Case Needed?", "type": "main", "index": 0 }]
+      ]
+    },
+    "Case Needed?": {
+      "main": [
+        [
+          { "node": "Insert Case (High ARR)", "type": "main", "index": 0 },
+          { "node": "Notify CSM (Escalation)", "type": "main", "index": 0 }
+        ],
+        [{ "node": "Send Email", "type": "main", "index": 0 }]
+      ]
+    },
+    "Insert Case (High ARR)": {
+      "main": [
+        [{ "node": "Send Email", "type": "main", "index": 0 }]
+      ]
+    },
+    "Notify CSM (Escalation)": {
+      "main": []
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {},
+  "meta": {
+    "templateCredsSetupCompleted": false,
+    "instanceId": ""
+  },
+  "tags": [
+    { "name": "novaseat" },
+    { "name": "churn-prevention" }
+  ]
+}

--- a/workflow-n8n/workflow4-weekly-reporting.json
+++ b/workflow-n8n/workflow4-weekly-reporting.json
@@ -1,0 +1,160 @@
+{
+  "name": "WF4 — Weekly Reporting",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            { "field": "cronExpression", "expression": "0 8 * * 1" }
+          ]
+        }
+      },
+      "id": "schedule-trigger",
+      "name": "Every Monday 08:00",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [0, 0]
+    },
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [0, 200]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT\n  week_start,\n  accounts_intercepted,\n  conversations_started,\n  churn_prevented,\n  csm_escalations,\n  messages_sent,\n  messages_replied\nFROM v_weekly_stats\nWHERE week_start = date_trunc('week', CURRENT_DATE - INTERVAL '7 days')::DATE\nLIMIT 1;",
+        "options": {}
+      },
+      "id": "fetch-weekly-stats",
+      "name": "Fetch Weekly Stats",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [260, 100],
+      "credentials": {
+        "postgres": { "id": "CONFIGURE_ME", "name": "NovaSeat PostgreSQL" }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT\n  COUNT(*) FILTER (WHERE risk_tier = 'Critical') AS critical_count,\n  COUNT(*) FILTER (WHERE risk_tier = 'High')     AS high_count,\n  COUNT(*) FILTER (WHERE risk_tier = 'Medium')   AS medium_count,\n  COUNT(*) FILTER (WHERE risk_tier = 'Low')      AS low_count,\n  COUNT(*)                                        AS total_accounts,\n  ROUND(AVG(churn_probability)::NUMERIC, 4)      AS avg_churn_prob\nFROM accounts\nWHERE churn_probability IS NOT NULL;",
+        "options": {}
+      },
+      "id": "fetch-risk-distribution",
+      "name": "Fetch Risk Distribution",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [260, 300],
+      "credentials": {
+        "postgres": { "id": "CONFIGURE_ME", "name": "NovaSeat PostgreSQL" }
+      }
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "combineBy": "combineAll",
+        "options": {}
+      },
+      "id": "merge-data",
+      "name": "Merge Stats",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [520, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ── Build Weekly Digest HTML ──\n\nconst stats = $input.all()[0].json;\n\nconst weekStart = stats.week_start || new Date(Date.now() - 7 * 86400000).toISOString().slice(0, 10);\nconst weekEnd = new Date(new Date(weekStart).getTime() + 6 * 86400000).toISOString().slice(0, 10);\n\nconst intercepted   = stats.accounts_intercepted   || 0;\nconst conversations = stats.conversations_started   || 0;\nconst prevented     = stats.churn_prevented          || 0;\nconst escalations   = stats.csm_escalations          || 0;\nconst sent          = stats.messages_sent             || 0;\nconst replied       = stats.messages_replied           || 0;\nconst replyRate     = sent > 0 ? ((replied / sent) * 100).toFixed(1) : '0.0';\n\nconst critical = stats.critical_count || 0;\nconst high     = stats.high_count     || 0;\nconst medium   = stats.medium_count   || 0;\nconst low      = stats.low_count      || 0;\nconst total    = stats.total_accounts || 0;\nconst avgProb  = stats.avg_churn_prob || 0;\n\nconst kpiRow = (label, value, color) =>\n  `<td style=\"text-align:center;padding:16px;\">`\n  + `<div style=\"font-size:32px;font-weight:bold;color:${color};\">${value}</div>`\n  + `<div style=\"font-size:13px;color:#6b7280;margin-top:4px;\">${label}</div>`\n  + `</td>`;\n\nconst riskBar = (label, count, color) => {\n  const pct = total > 0 ? ((count / total) * 100).toFixed(1) : 0;\n  return `<tr>`\n    + `<td style=\"padding:6px 12px;font-weight:600;color:${color};\">${label}</td>`\n    + `<td style=\"padding:6px 12px;text-align:right;\">${count}</td>`\n    + `<td style=\"padding:6px 12px;text-align:right;color:#6b7280;\">${pct}%</td>`\n    + `</tr>`;\n};\n\nconst html = `\n<div style=\"font-family:Arial,sans-serif;max-width:680px;margin:0 auto;padding:24px;background:#ffffff;\">\n  <div style=\"text-align:center;margin-bottom:32px;\">\n    <h1 style=\"color:#1a1a2e;margin:0;\">NovaSeat — Weekly Churn Report</h1>\n    <p style=\"color:#6b7280;margin:8px 0 0;\">${weekStart} to ${weekEnd}</p>\n  </div>\n\n  <table style=\"width:100%;border-collapse:collapse;margin-bottom:32px;\">\n    <tr style=\"background:#f8f7ff;border-radius:8px;\">\n      ${kpiRow('Accounts Intercepted', intercepted, '#4f46e5')}\n      ${kpiRow('Conversations Started', conversations, '#0891b2')}\n      ${kpiRow('Churn Prevented', prevented, '#16a34a')}\n      ${kpiRow('CSM Escalations', escalations, '#dc2626')}\n    </tr>\n  </table>\n\n  <table style=\"width:100%;border-collapse:collapse;margin-bottom:32px;\">\n    <tr style=\"background:#f8f7ff;\">\n      ${kpiRow('Messages Sent', sent, '#4f46e5')}\n      ${kpiRow('Replies Received', replied, '#0891b2')}\n      ${kpiRow('Reply Rate', replyRate + '%', '#16a34a')}\n    </tr>\n  </table>\n\n  <h2 style=\"color:#1a1a2e;font-size:18px;margin-bottom:12px;\">Current Risk Distribution</h2>\n  <table style=\"width:100%;border-collapse:collapse;margin-bottom:32px;\">\n    <thead><tr style=\"border-bottom:2px solid #e5e7eb;\">\n      <th style=\"text-align:left;padding:8px 12px;\">Tier</th>\n      <th style=\"text-align:right;padding:8px 12px;\">Accounts</th>\n      <th style=\"text-align:right;padding:8px 12px;\">%</th>\n    </tr></thead>\n    <tbody>\n      ${riskBar('Critical', critical, '#dc2626')}\n      ${riskBar('High', high, '#f59e0b')}\n      ${riskBar('Medium', medium, '#3b82f6')}\n      ${riskBar('Low', low, '#16a34a')}\n    </tbody>\n    <tfoot><tr style=\"border-top:2px solid #e5e7eb;font-weight:bold;\">\n      <td style=\"padding:8px 12px;\">Total</td>\n      <td style=\"padding:8px 12px;text-align:right;\">${total}</td>\n      <td style=\"padding:8px 12px;text-align:right;\">Avg prob: ${(avgProb * 100).toFixed(1)}%</td>\n    </tr></tfoot>\n  </table>\n\n  <p style=\"color:#9ca3af;font-size:12px;text-align:center;\">Generated automatically by NovaSeat Churn Prevention Platform</p>\n</div>\n`;\n\nreturn [{\n  json: {\n    weekStart,\n    weekEnd,\n    intercepted,\n    conversations,\n    prevented,\n    escalations,\n    sent,\n    replied,\n    replyRate: parseFloat(replyRate),\n    reportHtml: html,\n    reportData: {\n      risk_distribution: { critical, high, medium, low, total },\n      avg_churn_probability: avgProb,\n      kpis: { intercepted, conversations, prevented, escalations, sent, replied }\n    }\n  }\n}];"
+      },
+      "id": "build-report",
+      "name": "Build Report HTML",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [760, 200]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "INSERT INTO weekly_reports (\n  week_start, week_end,\n  accounts_intercepted, conversations_started, churn_prevented,\n  csm_escalations, messages_sent, messages_replied,\n  report_data, sent_to, sent_at\n) VALUES (\n  '{{ $json.weekStart }}',\n  '{{ $json.weekEnd }}',\n  {{ $json.intercepted }},\n  {{ $json.conversations }},\n  {{ $json.prevented }},\n  {{ $json.escalations }},\n  {{ $json.sent }},\n  {{ $json.replied }},\n  '{{ JSON.stringify($json.reportData) }}'::jsonb,\n  '{{HEAD_OF_CS_EMAIL}}',\n  NOW()\n)\nON CONFLICT (week_start) DO UPDATE SET\n  accounts_intercepted = EXCLUDED.accounts_intercepted,\n  conversations_started = EXCLUDED.conversations_started,\n  churn_prevented       = EXCLUDED.churn_prevented,\n  csm_escalations       = EXCLUDED.csm_escalations,\n  messages_sent         = EXCLUDED.messages_sent,\n  messages_replied      = EXCLUDED.messages_replied,\n  report_data           = EXCLUDED.report_data,\n  sent_at               = NOW();",
+        "options": {}
+      },
+      "id": "save-report",
+      "name": "Save Report to DB",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [1000, 200],
+      "credentials": {
+        "postgres": { "id": "CONFIGURE_ME", "name": "NovaSeat PostgreSQL" }
+      }
+    },
+    {
+      "parameters": {
+        "fromEmail": "reports@novaseat.dev",
+        "toEmail": "={{HEAD_OF_CS_EMAIL}}",
+        "subject": "=NovaSeat Weekly Churn Report — {{ $json.weekStart }} to {{ $json.weekEnd }}",
+        "html": "={{ $json.reportHtml }}",
+        "options": {}
+      },
+      "id": "send-report",
+      "name": "Send Report Email",
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 2.1,
+      "position": [1240, 200],
+      "credentials": {
+        "smtp": { "id": "CONFIGURE_ME", "name": "NovaSeat SMTP" }
+      }
+    }
+  ],
+  "connections": {
+    "Every Monday 08:00": {
+      "main": [
+        [{ "node": "Fetch Weekly Stats", "type": "main", "index": 0 }]
+      ]
+    },
+    "Manual Trigger": {
+      "main": [
+        [{ "node": "Fetch Weekly Stats", "type": "main", "index": 0 }]
+      ]
+    },
+    "Fetch Weekly Stats": {
+      "main": [
+        [{ "node": "Merge Stats", "type": "main", "index": 0 }]
+      ]
+    },
+    "Fetch Risk Distribution": {
+      "main": [
+        [{ "node": "Merge Stats", "type": "main", "index": 1 }]
+      ]
+    },
+    "Merge Stats": {
+      "main": [
+        [{ "node": "Build Report HTML", "type": "main", "index": 0 }]
+      ]
+    },
+    "Build Report HTML": {
+      "main": [
+        [{ "node": "Save Report to DB", "type": "main", "index": 0 }]
+      ]
+    },
+    "Save Report to DB": {
+      "main": [
+        [{ "node": "Send Report Email", "type": "main", "index": 0 }]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {},
+  "meta": {
+    "templateCredsSetupCompleted": false,
+    "instanceId": ""
+  },
+  "tags": [
+    { "name": "novaseat" },
+    { "name": "churn-prevention" }
+  ]
+}


### PR DESCRIPTION
## Summary
- **Workflow 2 (Churn Alert Monitor):** daily poll of `v_churn_alerts`, decision logic by risk_tier + ARR, personalized email templates, creates interventions/tasks/cases in DB
- **Workflow 4 (Weekly Reporting):** Monday digest with KPI cards, risk distribution table, HTML report saved to `weekly_reports` and emailed to Head of CS
- **README** with setup instructions, credential config, and placeholder reference

## To configure after import
- PostgreSQL credentials
- SMTP credentials
- `{{CALENDAR_LINK}}`, `{{HEAD_OF_CS_EMAIL}}` placeholders